### PR TITLE
 Alto hyp

### DIFF
--- a/alto2hocr.xsl
+++ b/alto2hocr.xsl
@@ -119,8 +119,8 @@ License: MIT License (MIT)
     <span class="ocrx_word" id="{mf:getId(@ID,'word',.)}" title="{mf:getBox(@HEIGHT,@WIDTH,@VPOS,@HPOS)}">
         <xsl:value-of select="@CONTENT"/>
         <xsl:if test="local-name(following-sibling::*[1]) = 'HYP'">
-             <xsl:text>-</xsl:text>
-         </xsl:if>
+            <xsl:text>-</xsl:text>
+        </xsl:if>
      </span>
   </xsl:template>
   


### PR DESCRIPTION
Translate ALTO <HYP> to a dash at the end of the preceding word
